### PR TITLE
Hide video search results if metadata and video owner do not match

### DIFF
--- a/src/pages/Home/VideoList.tsx
+++ b/src/pages/Home/VideoList.tsx
@@ -553,6 +553,13 @@ export const VideoList = ({ mode }: VideoListProps) => {
                   avatarUrl = userAvatarHash[videoObj?.user];
                 }
 
+                // nb. this prevents showing metadata for a video which
+                // belongs to a different user
+                if (videoObj?.user && videoObj?.videoReference?.name
+                    && videoObj.user != videoObj.videoReference.name) {
+                  return null;
+                }
+
                 if (hasHash && !videoObj?.videoImage && !videoObj?.image) {
                   return null;
                 }


### PR DESCRIPTION
This fixes (for me) the issue I ran across, where I posted a video under 'edbob' but then also posted metadata under 'edbob-testing' name, which referenced the same vid.  Q-Tube as of writing will show edbob-testing search result and plays video as though it belonged to that name.

So here I'm just suppressing any results which have such a mismatch.

I believe this is related somehow to #6 but I'm not clear how much or if it matters now.
