### PR TITLE
Add supported codecs to publish page

### DIFF
--- a/src/components/PublishVideo/PublishVideo.tsx
+++ b/src/components/PublishVideo/PublishVideo.tsx
@@ -712,6 +712,17 @@ export const PublishVideo = ({ editId, editContent }: NewCrowdfundProps) => {
                   Drag and drop a video files here or click to select files
                 </Typography>
               </Box>
+              <Box>
+                <Typography sx={{fontSize: "14px"}}>
+                  Supported File Containers: MP4, Ogg, WebM, WAV
+                </Typography>
+                <Typography sx={{fontSize: "14px"}}>
+                  Audio Codecs: FLAC, MP3, Opus, PCM (8/16/32-bit, μ-law), Vorbis
+                </Typography>
+                <Typography sx={{fontSize: "14px"}}>
+                  Video Codecs: AV1, VP8, VP9
+                </Typography>
+              </Box>
 
               <Box
                 sx={{


### PR DESCRIPTION
This completes the following item on the Qortal Q-Apps task list:
https://github.com/orgs/Qortal/projects/4/views/2?pane=issue&itemId=49345384

This change adds a list of supported codecs and file container types to Q-Tube that is displayed on the publishing page, when submitting a video and entering its details.