### PR TITLE
Fixed Video History bugs

### DIFF
--- a/src/components/common/VideoFileElement.tsx
+++ b/src/components/common/VideoFileElement.tsx
@@ -35,18 +35,24 @@ export const VideoFileElement = ({
   const [hasAddedToHistory, setHasAddedToHistory] = useState(false);
 
   const handleDownloadStart = () => {
-    if (!isHydratedWatchedHistory || hasAddedToHistory || !videoReference) return;
+    if (!isHydratedWatchedHistory || hasAddedToHistory || !videoReference)
+      return;
 
     // Add to history when download is initiated
     const videoHistoryEntry = {
-      identifier: videoReference.identifier,
+      identifier: videoReference.identifier + '_metadata',
       name: videoReference.name,
-      service: videoReference.service,
+      service: 'DOCUMENT',
       created: videoReference.created || Date.now(),
       watchedAt: Date.now(),
     };
 
-    addToWatchHistory(videoHistoryEntry, watchedHistory, setWatchedHistory, lists);
+    addToWatchHistory(
+      videoHistoryEntry,
+      watchedHistory,
+      setWatchedHistory,
+      lists
+    );
     setHasAddedToHistory(true);
   };
 

--- a/src/components/common/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/common/VideoPlayer/VideoPlayer.tsx
@@ -1,10 +1,11 @@
 import { Box } from '@mui/material';
 import CSS from 'csstype';
 
-import { Service, VideoPlayer as QappVideoPlayer } from 'qapp-core';
-import { useEffect, useRef } from 'react';
+import { Service, VideoPlayer as QappVideoPlayer, useGlobal } from 'qapp-core';
+import { useCallback, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useIsSmall } from '../../../hooks/useIsSmall';
+import { usePersistedState } from '../../../state/persist/persist.ts';
 
 export interface VideoStyles {
   videoContainer?: CSS.Properties;
@@ -36,6 +37,34 @@ export const VideoPlayer = ({ ...props }: VideoPlayerProps) => {
   const isSmall = useIsSmall();
   const videoRef = useRef(null);
   const location = useLocation();
+  const { lists } = useGlobal();
+  const [watchedHistory, setWatchedHistory, isHydratedWatchedHistory] =
+    usePersistedState<any[]>('watched-v1', []);
+
+  const onPlay = useCallback(() => {
+    if (!isHydratedWatchedHistory) return;
+    const videoReference = {
+      identifier: props?.jsonId,
+      name: props?.user,
+      service: 'DOCUMENT',
+      created: props?.created || Date.now(),
+      watchedAt: Date.now(),
+    };
+
+    setWatchedHistory((prev) => {
+      const exists = prev.some(
+        (v) =>
+          v.identifier === videoReference.identifier &&
+          v.name === videoReference.name &&
+          v.service === videoReference.service
+      );
+
+      if (exists) return prev; // Already watched, don't add again
+      lists.deleteList(`watched-history`);
+      // Add to beginning, then keep only latest 200
+      return [videoReference, ...prev].slice(0, 200);
+    });
+  }, [props?.jsonId, props?.user, isHydratedWatchedHistory]);
 
   // Cleanup video player on unmount
   useEffect(() => {
@@ -68,6 +97,7 @@ export const VideoPlayer = ({ ...props }: VideoPlayerProps) => {
         flexDirection: 'column',
         ...(props?.parentStyles || {}),
       }}
+      onClick={onPlay}
     >
       <QappVideoPlayer
         poster={props.poster}
@@ -79,6 +109,7 @@ export const VideoPlayer = ({ ...props }: VideoPlayerProps) => {
         }}
         autoPlay={props?.autoPlay}
         onEnded={props?.onEnd}
+        onPlay={onPlay}
         filename={props?.filename}
         path={location.pathname}
         styling={{

--- a/src/pages/History/History.tsx
+++ b/src/pages/History/History.tsx
@@ -1,6 +1,7 @@
 import ClearAllIcon from '@mui/icons-material/ClearAll';
 import { Box, Button, Divider } from '@mui/material';
 import { Spacer, useGlobal } from 'qapp-core';
+import { useEffect } from 'react';
 import { PageSubTitle } from '../../components/common/General/GeneralStyles.tsx';
 import { PageTransition } from '../../components/common/PageTransition.tsx';
 import { useIsSmall } from '../../hooks/useIsSmall.tsx';
@@ -12,6 +13,12 @@ export const History = () => {
   const isSmall = useIsSmall();
   const [watchedHistory, setWatchedHistory, isHydratedWatchedHistory] =
     usePersistedState('watched-v1', []);
+
+  // useEffect(() => {  // print statement for debugging
+  //   if (isHydratedWatchedHistory && watchedHistory?.length > 0) {
+  //     console.log(`Video History: `, watchedHistory);
+  //   }
+  // }, [isHydratedWatchedHistory, watchedHistory]);
 
   if (!isHydratedWatchedHistory) {
     return null;

--- a/src/pages/Home/Components/VideoListItem.tsx
+++ b/src/pages/Home/Components/VideoListItem.tsx
@@ -13,10 +13,8 @@ import ResponsiveImage from '../../../components/ResponsiveImage';
 import { fontSizeSmall, minDuration } from '../../../constants/Misc';
 import { useIsMobile } from '../../../hooks/useIsMobile';
 import { editPlaylistAtom } from '../../../state/publish/playlist';
-import { usePersistedState } from '../../../state/persist/persist';
 import { formatTime, formatBytes } from '../../../utils/numberFunctions';
 import { formatDate } from '../../../utils/time';
-import { addToWatchHistory } from '../../../utils/watchHistory';
 import { VideoCardImageContainer } from './VideoCardImageContainer';
 import {
   BlockIconContainer,
@@ -60,8 +58,6 @@ export const VideoListItem = ({
   const [showIcons, setShowIcons] = useState<boolean>(false);
   const theme = useTheme();
   const { lists } = useGlobal();
-  const [watchedHistory, setWatchedHistory, isHydratedWatchedHistory] =
-    usePersistedState<any[]>('watched-v1', []);
 
   const { deleteResource } = lists;
   const setEditPlaylist = useSetAtom(editPlaylistAtom);
@@ -69,18 +65,6 @@ export const VideoListItem = ({
   const isPlaylist = qortalMetadata?.service === 'PLAYLIST';
 
   const handleVideoClick = () => {
-    if (!isHydratedWatchedHistory) return;
-
-    const videoHistoryEntry = {
-      identifier: qortalMetadata.identifier,
-      name: qortalMetadata.name,
-      service: qortalMetadata.service,
-      created: qortalMetadata.created || Date.now(),
-      watchedAt: Date.now(),
-    };
-
-    addToWatchHistory(videoHistoryEntry, watchedHistory, setWatchedHistory, lists);
-
     navigate(
       `/video/${encodeURIComponent(qortalMetadata?.name)}/${qortalMetadata?.identifier}`
     );


### PR DESCRIPTION
History was being updated when clicking on VideoListItem.tsx, now it is updated when clicking on the video itself, and when video plays.

Fixed bug where VideoFileElement.tsx was adding the identifier and service of the video publish instead of the metadata publish.